### PR TITLE
Reduce heap size

### DIFF
--- a/micropython/source/microbit/mprun.c
+++ b/micropython/source/microbit/mprun.c
@@ -15,7 +15,7 @@
 #include "memory.h"
 
 extern void microbit_init(void);
-    
+
 void microbit_display_exception(mp_obj_t exc_in) {
     mp_uint_t n, *values;
     mp_obj_exception_get_traceback(exc_in, &n, &values);
@@ -99,7 +99,7 @@ void mp_run(void) {
     mp_stack_set_limit(1800); // stack is 2k
 
     // allocate the heap statically in the bss
-    static uint32_t heap[9692 / 4];
+    static uint32_t heap[9292 / 4];
     gc_init(heap, (uint8_t*)heap + sizeof(heap));
 
     /*


### PR DESCRIPTION
There is a similar issue to builds failing with `region RAM overflowed with stack` mentioned in
https://github.com/bbcmicrobit/micropython/issues/363.  

I reduced it around 400 bytes to get `yotta build` to run without the mentioned error in NixOS.